### PR TITLE
implement a new migration flow with import and removed blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+## v2.0.0-beta
+
+Target azurerm version: v4.0.0
+
+FEATURES:
+- The new migration flow uses `import` and `removed` block instead of importing resources and removing resources from terraform state directly.
+- Support `working-dir` flag to specify the working directory
+
+## v1.15.0
+Target azurerm version: v3.114.0
+
+## v1.14.0
+Target azurerm version: v3.110.0
+
+## v1.13.0
+Target azurerm version: v3.99.0
+Target azapi version: v1.13.0
+
+## v1.12.0
+Target azurerm version: v3.83.0
+
+## v1.11.0
+Target azurerm version: v3.83.0
+
+## v1.10.0
+Target azurerm version: v3.79.0
+
+## v1.9.0
+Target azurerm version: v3.71.0
+
+## v1.8.0
+Target azurerm version: v3.66.0
+
+## v1.7.0
+Target azurerm version: v3.61.0
+
+ENHANCEMENTS:
+- Refactor: use `tfadd` to generate config from state
+
+BUG FIXES:
+- Fix import with `for_each` statement
+
+## v1.6.0
+Target azurerm version: v3.55.0
+
+ENHANCEMENTS:
+- Refactor: use aztft to get resource type & upgrade to go 1.19
+
+BUG FIXES:
+- Fix import with `count` statement
+
+## v1.5.0
+Target azurerm version: v3.50.0
+
+## v1.4.0
+Target azurerm version: v3.45.0
+
+## v1.3.0
+Target azurerm version: v3.41.0
+
+## v1.2.0
+Target azurerm version: v3.37.0
+
+## v1.1.0
+Target azurerm version: v3.31.0
+
+## v1.0.0
+Target azurerm version: v3.24.0
+
+## v0.6.0
+Target azurerm version: v3.22.0
+
+## v0.5.0
+Target azurerm version: v3.18.0
+
+FEATURES:
+- Refresh state after migrating update resources.
+
+## v0.4.0
+Target azurerm version: v3.11.0
+
+## v0.3.0
+Target azurerm version: v3.1.0
+
+## v0.2.0
+Target azurerm version: v3.0.2
+
+## v0.1.0
+Target azurerm version: v2.99.0
+
+FEATURES:
+- Support resource `azapi_resource` migration
+- Support resource `azapi_update_resource` migration
+- Support meta-argument `for_each`
+- Support meta-argument `count`
+- Support meta-argument `depends_on`, `lifecycle` and `provisioner`
+- Support dependency injection in array and primitive value.
+- Support dependency injection in Map and other complicated struct value.
+- Support user input when there are multiple/none `azurerm` resource match for the resource id
+- Support migration based on `azurerm` provider's property coverage
+- Support ignore terraform addresses listed in file `azapi2azurerm.ignore`

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,3 +17,7 @@ test:
 lint:
 	@echo "==> Checking source code against linters..."
 	@if command -v golangci-lint; then (golangci-lint run ./...); else ($(GOPATH)/bin/golangci-lint run ./...); fi
+
+terrafmt:
+	@echo "==> Fixing acceptance test terraform blocks code with terrafmt..."
+	@find . | egrep "_test.go" | sort | while read f; do terrafmt fmt -f $$f; done

--- a/azurerm/coverage/coverage.go
+++ b/azurerm/coverage/coverage.go
@@ -36,16 +36,10 @@ func GetApiVersion(idPattern string) string {
 }
 
 func GetPutCoverage(props []string, idPattern string) ([]string, []string) {
-	if true {
-		return props, nil
-	}
 	return getCoverage(props, "PUT", idPattern)
 }
 
 func GetGetCoverage(props []string, idPattern string) ([]string, []string) {
-	if true {
-		return props, nil
-	}
 	return getCoverage(props, "GET", idPattern)
 }
 

--- a/azurerm/coverage/coverage.go
+++ b/azurerm/coverage/coverage.go
@@ -36,10 +36,16 @@ func GetApiVersion(idPattern string) string {
 }
 
 func GetPutCoverage(props []string, idPattern string) ([]string, []string) {
+	if true {
+		return props, nil
+	}
 	return getCoverage(props, "PUT", idPattern)
 }
 
 func GetGetCoverage(props []string, idPattern string) ([]string, []string) {
+	if true {
+		return props, nil
+	}
 	return getCoverage(props, "GET", idPattern)
 }
 

--- a/cmd/migrate_command.go
+++ b/cmd/migrate_command.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/azapi2azurerm/azurerm"
@@ -17,26 +17,31 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mitchellh/cli"
+	"github.com/zclconf/go-cty/cty"
 )
 
 const filenameImport = "imports.tf"
 const providerConfig = `
 provider "azurerm" {
   features {}
+  subscription_id = "%s"
 }
 `
 const tempDir = "temp"
 
 type MigrateCommand struct {
-	Ui      cli.Ui
-	Verbose bool
-	Strict  bool
+	Ui         cli.Ui
+	Verbose    bool
+	Strict     bool
+	workingDir string
 }
 
 func (c *MigrateCommand) flags() *flag.FlagSet {
 	fs := defaultFlagSet("plan")
 	fs.BoolVar(&c.Verbose, "v", false, "whether show terraform logs")
 	fs.BoolVar(&c.Strict, "strict", false, "strict mode: API versions must be matched")
+	fs.StringVar(&c.workingDir, "working-dir", "", "path to Terraform configuration files")
+
 	fs.Usage = func() { c.Ui.Error(c.Help()) }
 	return fs
 }
@@ -51,9 +56,13 @@ func (c MigrateCommand) Run(args []string) int {
 		return 1
 	}
 
+	if c.workingDir == "" {
+		c.workingDir, _ = os.Getwd()
+	}
+	log.Printf("[INFO] working directory: %s", c.workingDir)
+
 	log.Printf("[INFO] initializing terraform...")
-	workingDirectory, _ := os.Getwd()
-	terraform, err := tf.NewTerraform(workingDirectory, c.Verbose)
+	terraform, err := tf.NewTerraform(c.workingDir, c.Verbose)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -83,27 +92,11 @@ func (c MigrateCommand) MigrateGenericResource(terraform *tf.Terraform, resource
 	log.Printf("[INFO] -----------------------------------------------")
 	log.Printf("[INFO] task: migrate azapi_resource")
 
-	// generate import config
-	config := ""
-	for _, resource := range resources {
-		config += resource.EmptyImportConfig()
-	}
 	workingDirectory := terraform.GetWorkingDirectory()
-	if err := os.WriteFile(filepath.Join(workingDirectory, filenameImport), []byte(config), 0600); err != nil {
-		log.Fatal(err)
-	}
 
 	// import and generate config
 	for index, r := range resources {
 		log.Printf("[INFO] migrating resource %s (%d instances) to resource %s...", r.OldAddress(nil), len(r.Instances), r.NewAddress(nil))
-		// import into real state
-		for _, instance := range r.Instances {
-			address := r.NewAddress(instance.Index)
-			log.Printf("[INFO] importing %s to %s...", instance.ResourceId, address)
-			if err := terraform.Import(address, instance.ResourceId); err != nil {
-				log.Printf("[Error] error importing %s : %s", address, instance.ResourceId)
-			}
-		}
 
 		// write empty config to temp dir for import
 		tempDirectoryCreate(workingDirectory)
@@ -113,7 +106,14 @@ func (c MigrateCommand) MigrateGenericResource(terraform *tf.Terraform, resource
 			log.Fatal(err)
 		}
 
-		config := providerConfig
+		subscriptionId := ""
+		for _, instance := range r.Instances {
+			if strings.HasPrefix(instance.ResourceId, "/subscriptions/") {
+				subscriptionId = strings.Split(instance.ResourceId, "/")[2]
+				break
+			}
+		}
+		config := fmt.Sprintf(providerConfig, subscriptionId)
 		for _, instance := range r.Instances {
 			if !r.IsMultipleResources() {
 				config += fmt.Sprintf("resource \"%s\" \"%s\" {}\n", r.ResourceType, r.Label)
@@ -195,17 +195,6 @@ func (c MigrateCommand) MigrateGenericResource(terraform *tf.Terraform, resource
 	}
 	tempDirectoryCleanup(workingDirectory)
 
-	// remove from state
-	for _, r := range resources {
-		if r.Migrated {
-			log.Printf("[INFO] removing %s from state", r.OldAddress(nil))
-			exec := terraform.GetExec()
-			if err := exec.StateRm(context.TODO(), r.OldAddress(nil)); err != nil {
-				log.Printf("[ERROR] error removing %s from state: %+v", r.OldAddress(nil), err)
-			}
-		}
-	}
-
 	// migrate depends_on, lifecycle, provisioner
 	for index, r := range resources {
 		if existingBlock, err := helper.GetResourceBlock(workingDirectory, r.OldAddress(nil)); err == nil && existingBlock != nil {
@@ -221,15 +210,40 @@ func (c MigrateCommand) MigrateGenericResource(terraform *tf.Terraform, resource
 	}
 
 	// remove from config
-	if err := os.RemoveAll(filepath.Join(workingDirectory, filenameImport)); err != nil {
-		log.Fatal(err)
-	}
 	for _, r := range resources {
 		if r.Migrated {
 			log.Printf("[INFO] removing %s from config", r.OldAddress(nil))
-			if err := helper.ReplaceResourceBlock(workingDirectory, r.OldAddress(nil), r.Block); err != nil {
+
+			importBlock := hclwrite.NewBlock("import", nil)
+			if r.IsMultipleResources() {
+				forEachMap := make(map[string]cty.Value)
+				for _, instance := range r.Instances {
+					switch v := instance.Index.(type) {
+					case string:
+						forEachMap[instance.ResourceId] = cty.StringVal(v)
+					default:
+						value, _ := strconv.ParseInt(fmt.Sprintf("%v", v), 10, 64)
+						forEachMap[instance.ResourceId] = cty.NumberIntVal(value)
+					}
+				}
+				importBlock.Body().SetAttributeValue("for_each", cty.MapVal(forEachMap))
+				importBlock.Body().SetAttributeTraversal("id", hcl.Traversal{hcl.TraverseRoot{Name: "each"}, hcl.TraverseAttr{Name: "key"}})
+				importBlock.Body().SetAttributeTraversal("to", hcl.Traversal{hcl.TraverseRoot{Name: r.ResourceType}, hcl.TraverseAttr{Name: fmt.Sprintf("%s[each.value]", r.Label)}})
+			} else {
+				importBlock.Body().SetAttributeValue("id", cty.StringVal(r.Instances[0].ResourceId))
+				importBlock.Body().SetAttributeTraversal("to", hcl.Traversal{hcl.TraverseRoot{Name: r.ResourceType}, hcl.TraverseAttr{Name: r.Label}})
+			}
+
+			removedBlock := hclwrite.NewBlock("removed", nil)
+			removedBlock.Body().SetAttributeTraversal("from", hcl.Traversal{hcl.TraverseRoot{Name: "azapi_resource"}, hcl.TraverseAttr{Name: r.Label}})
+			removedLifecycleBlock := hclwrite.NewBlock("lifecycle", nil)
+			removedLifecycleBlock.Body().SetAttributeValue("destroy", cty.BoolVal(false))
+			removedBlock.Body().AppendBlock(removedLifecycleBlock)
+
+			if err := helper.ReplaceResourceBlock(workingDirectory, r.OldAddress(nil), []*hclwrite.Block{removedBlock, importBlock, r.Block}); err != nil {
 				log.Printf("[ERROR] error removing %s from state: %+v", r.OldAddress(nil), err)
 			}
+
 		}
 	}
 
@@ -259,7 +273,14 @@ func (c MigrateCommand) MigrateGenericUpdateResource(terraform *tf.Terraform, re
 	log.Printf("[INFO] task: migrate azapi_update_resource")
 
 	// generate import config
-	config := providerConfig
+	subscriptionId := ""
+	for _, instance := range resources {
+		if strings.HasPrefix(instance.Id, "/subscriptions/") {
+			subscriptionId = strings.Split(instance.Id, "/")[2]
+			break
+		}
+	}
+	config := fmt.Sprintf(providerConfig, subscriptionId)
 	for _, resource := range resources {
 		config += resource.EmptyImportConfig()
 	}
@@ -312,31 +333,20 @@ func (c MigrateCommand) MigrateGenericUpdateResource(terraform *tf.Terraform, re
 		}
 	}
 
-	// remove from state
-	for _, r := range resources {
-		if r.Migrated {
-			log.Printf("[INFO] removing %s from state", r.OldAddress())
-			exec := terraform.GetExec()
-			if err := exec.StateRm(context.TODO(), r.OldAddress()); err != nil {
-				log.Printf("[ERROR] error removing %s from state: %+v", r.OldAddress(), err)
-			}
-		}
-	}
-
 	// remove from config
 	for _, r := range resources {
 		if r.Migrated {
 			log.Printf("[INFO] removing %s from config", r.OldAddress())
-			if err := helper.ReplaceResourceBlock(workingDirectory, r.OldAddress(), nil); err != nil {
+			removedBlock := hclwrite.NewBlock("removed", nil)
+			removedBlock.Body().SetAttributeTraversal("from", hcl.Traversal{hcl.TraverseRoot{Name: "azapi_update_resource"}, hcl.TraverseAttr{Name: r.OldLabel}})
+			removedLifecycleBlock := hclwrite.NewBlock("lifecycle", nil)
+			removedLifecycleBlock.Body().SetAttributeValue("destroy", cty.BoolVal(false))
+			removedBlock.Body().AppendBlock(removedLifecycleBlock)
+
+			if err := helper.ReplaceResourceBlock(workingDirectory, r.OldAddress(), []*hclwrite.Block{removedBlock}); err != nil {
 				log.Printf("[ERROR] error removing %s from state: %+v", r.OldAddress(), err)
 			}
 		}
-	}
-
-	log.Println("[INFO] refreshing state for migrated resources...")
-	err = terraform.RefreshState(newAddrs)
-	if err != nil {
-		log.Printf("refreshing state: %+v", err)
 	}
 
 	tempDirectoryCleanup(workingDirectory)

--- a/cmd/migrate_command.go
+++ b/cmd/migrate_command.go
@@ -298,7 +298,6 @@ func (c MigrateCommand) MigrateGenericUpdateResource(terraform *tf.Terraform, re
 	}
 
 	// import and generate config
-	newAddrs := make([]string, 0)
 	for index, r := range resources {
 		log.Printf("[INFO] migrating resource %s to resource %s", r.OldAddress(), r.NewAddress())
 		if block, err := importAndGenerateConfig(tempTerraform, r.NewAddress(), r.Id, r.ResourceType, true); err == nil {
@@ -309,7 +308,6 @@ func (c MigrateCommand) MigrateGenericUpdateResource(terraform *tf.Terraform, re
 			}
 			resources[index].Block = helper.InjectReference(resources[index].Block, resources[index].References)
 			resources[index].Migrated = true
-			newAddrs = append(newAddrs, r.NewAddress())
 			log.Printf("[INFO] %s has migrated to %s", r.OldAddress(), r.NewAddress())
 		} else {
 			log.Printf("[ERROR] %+v", err)

--- a/cmd/migrate_command_test.go
+++ b/cmd/migrate_command_test.go
@@ -275,27 +275,27 @@ resource "azapi_resource" "test" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = local.AutomationSku
       }
     }
-  })
+  }
 }
 
 resource "azapi_resource" "test2" {
-  name        = "${var.AutomationName}another"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
-  location    = azurerm_resource_group.test.location
-  body = jsonencode({
+  name      = "${var.AutomationName}another"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  location  = azurerm_resource_group.test.location
+  body = {
     properties = {
       sku = {
-        name = jsondecode(azapi_resource.test.output).properties.sku.name
+        name = azapi_resource.test.output.properties.sku.name
       }
     }
-  })
+  }
 }
 
 resource "azurerm_automation_account" "test1" {
@@ -309,19 +309,19 @@ resource "azapi_update_resource" "test" {
   resource_id            = azurerm_automation_account.test1.id
   type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
   response_export_values = ["properties.sku"]
-  body = jsonencode({
+  body = {
     tags = {
       key = var.Label
     }
-  })
+  }
 }
 
 output "accountName" {
-  value = jsondecode(azapi_resource.test.output).name
+  value = azapi_resource.test.output.name
 }
 
 output "patchAccountSKU" {
-  value = jsondecode(azapi_update_resource.test.output).properties.sku.name
+  value = azapi_update_resource.test.output.properties.sku.name
 }
 `, template(), randomResourceName(), randomResourceName())
 }
@@ -350,22 +350,22 @@ variable "accounts" {
 
 
 resource "azapi_resource" "test" {
-  name        = "henglu${each.value.name}"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  name      = "henglu${each.value.name}"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
 
   location = azurerm_resource_group.test.location
   identity {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = each.value.sku
       }
     }
-  })
+  }
 
   for_each = var.accounts
 }
@@ -395,31 +395,29 @@ variable "defName" {
 }
 
 resource "azapi_resource" "test" {
-  name        = "%s"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Network/serviceEndpointPolicies@2020-11-01"
+  name      = "%s"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Network/serviceEndpointPolicies@2020-11-01"
 
-  body = <<BODY
-{
-    "location": "westeurope",
-    "tags": {},
-    "properties": {
-        "serviceEndpointPolicyDefinitions": [
-            {
-                "name": "${var.defName}",
-                "properties": {
-                    "service": "Microsoft.Storage",
-                    "description": "${var.description}",
-                    "serviceResources": [
-                        "${azurerm_storage_account.test.id}",
-                        "${azurerm_resource_group.test.id}"
-                    ]
-                }
-            }
-        ]
+  body = {
+    location = "westeurope"
+    tags     = {}
+    properties = {
+      serviceEndpointPolicyDefinitions = [
+        {
+          name = var.defName
+          properties = {
+            service     = "Microsoft.Storage"
+            description = var.description
+            serviceResources = [
+              azurerm_storage_account.test.id,
+              azurerm_resource_group.test.id
+            ]
+          }
+        }
+      ]
     }
-}
-  BODY
+  }
 }
 `, template(), randomResourceName(), randomResourceName())
 }
@@ -429,17 +427,17 @@ func count() string {
 %s
 
 resource "azapi_resource" "test" {
-  name        = "%s${count.index}"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
-  location    = azurerm_resource_group.test.location
-  body = jsonencode({
+  name      = "%s${count.index}"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  location  = azurerm_resource_group.test.location
+  body = {
     properties = {
       sku = {
         name = "Basic"
       }
     }
-  })
+  }
 
   count = 2
 }
@@ -478,25 +476,23 @@ variable "action" {
 resource "azapi_update_resource" "test" {
   resource_id = azurerm_container_registry.test.id
   type        = "Microsoft.ContainerRegistry/registries@2019-05-01"
-  body        = <<BODY
-{
-    "properties": {
-        "networkRuleSet": {
-            "defaultAction": "Deny",
-            "ipRules": [
-                {
-                    "action": "${var.action}",
-                    "value": "7.7.7.7"
-                },
-                {
-                    "action": "${var.action}",
-                    "value": "2.2.2.2"
-                }
-            ]
-        }
+  body = {
+    properties = {
+      networkRuleSet = {
+        defaultAction = "Deny"
+        ipRules = [
+          {
+            action = var.action
+            value  = "7.7.7.7"
+          },
+          {
+            action = var.action
+            value  = "2.2.2.2"
+          }
+        ]
+      }
     }
-}
-    BODY
+  }
 }
 `, template(), randomResourceName())
 }
@@ -516,13 +512,13 @@ resource "azapi_resource" "test" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = "Basic"
       }
     }
-  })
+  }
 
   depends_on = [azurerm_resource_group.test]
 
@@ -538,22 +534,22 @@ resource "azapi_resource" "test" {
 
 
 resource "azapi_resource" "test1" {
-  name                   = "%s"
-  parent_id              = azurerm_resource_group.test.id
-  type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  name      = "%s"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
 
   location = azurerm_resource_group.test.location
   identity {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = "Basic"
       }
     }
-  })
+  }
 
   depends_on = [azurerm_resource_group.test, azapi_resource.test]
 
@@ -610,10 +606,10 @@ resource "azapi_resource" "test" {
 }
 
 resource "azapi_resource" "test2" {
-  name        = "${var.AutomationName}another"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
-  location    = azurerm_resource_group.test.location
+  name      = "${var.AutomationName}another"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  location  = azurerm_resource_group.test.location
   body = {
     properties = {
       sku = {
@@ -675,9 +671,9 @@ variable "accounts" {
 
 
 resource "azapi_resource" "test" {
-  name        = "henglu${each.value.name}"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  name      = "henglu${each.value.name}"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
 
   location = azurerm_resource_group.test.location
   identity {
@@ -720,27 +716,27 @@ variable "defName" {
 }
 
 resource "azapi_resource" "test" {
-  name        = "%s"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Network/serviceEndpointPolicies@2020-11-01"
+  name      = "%s"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Network/serviceEndpointPolicies@2020-11-01"
 
   body = {
     location = "westeurope"
-    tags = {}
+    tags     = {}
     properties = {
-        serviceEndpointPolicyDefinitions = [
-            {
-                name= var.defName
-                properties = {
-                    service = "Microsoft.Storage"
-                    description = var.description
-                    serviceResources= [
-                        azurerm_storage_account.test.id,
-                        azurerm_resource_group.test.id
-                    ]
-                }
-            }
-        ]
+      serviceEndpointPolicyDefinitions = [
+        {
+          name = var.defName
+          properties = {
+            service     = "Microsoft.Storage"
+            description = var.description
+            serviceResources = [
+              azurerm_storage_account.test.id,
+              azurerm_resource_group.test.id
+            ]
+          }
+        }
+      ]
     }
   }
 }
@@ -752,10 +748,10 @@ func count_payload() string {
 %s
 
 resource "azapi_resource" "test" {
-  name        = "%s${count.index}"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
-  location    = azurerm_resource_group.test.location
+  name      = "%s${count.index}"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  location  = azurerm_resource_group.test.location
   body = {
     properties = {
       sku = {
@@ -802,21 +798,21 @@ resource "azapi_update_resource" "test" {
   resource_id = azurerm_container_registry.test.id
   type        = "Microsoft.ContainerRegistry/registries@2019-05-01"
   body = {
-	properties = {
-		networkRuleSet = {
-			defaultAction = "Deny"
-			ipRules = [
-				{
-					action = var.action
-					value  = "7.7.7.7"
-				},
-				{
-					action = var.action
-					value  = "2.2.2.2"
-				}
-			]
-		}
-	}
+    properties = {
+      networkRuleSet = {
+        defaultAction = "Deny"
+        ipRules = [
+          {
+            action = var.action
+            value  = "7.7.7.7"
+          },
+          {
+            action = var.action
+            value  = "2.2.2.2"
+          }
+        ]
+      }
+    }
   }
 }
 `, template(), randomResourceName())
@@ -859,9 +855,9 @@ resource "azapi_resource" "test" {
 
 
 resource "azapi_resource" "test1" {
-  name                   = "%s"
-  parent_id              = azurerm_resource_group.test.id
-  type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  name      = "%s"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
 
   location = azurerm_resource_group.test.location
   identity {

--- a/cmd/plan_command.go
+++ b/cmd/plan_command.go
@@ -18,15 +18,17 @@ import (
 )
 
 type PlanCommand struct {
-	Ui      cli.Ui
-	Verbose bool
-	Strict  bool
+	Ui         cli.Ui
+	Verbose    bool
+	Strict     bool
+	workingDir string
 }
 
 func (c *PlanCommand) flags() *flag.FlagSet {
 	fs := defaultFlagSet("plan")
 	fs.BoolVar(&c.Verbose, "v", false, "whether show terraform logs")
 	fs.BoolVar(&c.Strict, "strict", false, "strict mode: API versions must be matched")
+	fs.StringVar(&c.workingDir, "working-dir", "", "path to Terraform configuration files")
 	fs.Usage = func() { c.Ui.Error(c.Help()) }
 	return fs
 }
@@ -42,8 +44,10 @@ func (c PlanCommand) Run(args []string) int {
 	}
 
 	log.Printf("[INFO] initializing terraform...")
-	workingDirectory, _ := os.Getwd()
-	terraform, err := tf.NewTerraform(workingDirectory, c.Verbose)
+	if c.workingDir == "" {
+		c.workingDir, _ = os.Getwd()
+	}
+	terraform, err := tf.NewTerraform(c.workingDir, c.Verbose)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/case1 - basic/main - migrated.tf
+++ b/examples/case1 - basic/main - migrated.tf
@@ -35,11 +35,73 @@ locals {
   AutomationSku = "Basic"
 }
 
+# resource "azapi_resource" "test" {
+#   name                   = var.AutomationName
+#   parent_id              = azurerm_resource_group.test.id
+#   type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+#   response_export_values = ["name", "identity", "properties.sku"]
+# 
+#   location = azurerm_resource_group.test.location
+#   identity {
+#     type = "SystemAssigned"
+#   }
+# 
+#   body = {
+#     properties = {
+#       sku = {
+#         name = local.AutomationSku
+#       }
+#     }
+#   }
+# }
+# 
+
+removed {
+  from = azapi_resource.test
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hl1214-resource-group/providers/Microsoft.Automation/automationAccounts/hl1214"
+  to = azurerm_automation_account.test
+}
+
 resource "azurerm_automation_account" "test" {
   location            = azurerm_resource_group.test.location
   name                = var.AutomationName
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "Basic"
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# resource "azapi_resource" "test2" {
+#   name      = "${var.AutomationName}another"
+#   parent_id = azurerm_resource_group.test.id
+#   type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+#   location  = azurerm_resource_group.test.location
+#   body = {
+#     properties = {
+#       sku = {
+#         name = azapi_resource.test.output.properties.sku.name
+#       }
+#     }
+#   }
+# }
+# 
+removed {
+  from = azapi_resource.test2
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctest3348/providers/Microsoft.Automation/automationAccounts/acctest4893another"
+  to = azurerm_automation_account.test2
 }
 
 resource "azurerm_automation_account" "test2" {
@@ -59,6 +121,24 @@ resource "azurerm_automation_account" "test1" {
   }
 }
 
+# resource "azapi_update_resource" "test" {
+#   resource_id            = azurerm_automation_account.test1.id
+#   type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+#   response_export_values = ["properties.sku"]
+#   body = {
+#     tags = {
+#       key = var.Label
+#     }
+#   }
+# }
+# 
+removed {
+  from = azapi_update_resource.test
+  lifecycle {
+    destroy = false
+  }
+}
+
 output "accountName" {
   value = azurerm_automation_account.test.name
 }
@@ -66,4 +146,3 @@ output "accountName" {
 output "patchAccountSKU" {
   value = azurerm_automation_account.test1.sku_name
 }
-

--- a/examples/case1 - basic/main.tf
+++ b/examples/case1 - basic/main.tf
@@ -46,27 +46,27 @@ resource "azapi_resource" "test" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = local.AutomationSku
       }
     }
-  })
+  }
 }
 
 resource "azapi_resource" "test2" {
-  name        = "${var.AutomationName}another"
-  parent_id   = azurerm_resource_group.test.id
-  type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
-  location    = azurerm_resource_group.test.location
-  body = jsonencode({
+  name      = "${var.AutomationName}another"
+  parent_id = azurerm_resource_group.test.id
+  type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+  location  = azurerm_resource_group.test.location
+  body = {
     properties = {
       sku = {
         name = jsondecode(azapi_resource.test.output).properties.sku.name
       }
     }
-  })
+  }
 }
 
 resource "azurerm_automation_account" "test1" {
@@ -80,17 +80,17 @@ resource "azapi_update_resource" "test" {
   resource_id            = azurerm_automation_account.test1.id
   type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
   response_export_values = ["properties.sku"]
-  body = jsonencode({
+  body = {
     tags = {
       key = var.Label
     }
-  })
+  }
 }
 
 output "accountName" {
-  value = jsondecode(azapi_resource.test.output).name
+  value = azapi_resource.test.output.name
 }
 
 output "patchAccountSKU" {
-  value = jsondecode(azapi_update_resource.test.output).properties.sku.name
+  value = azapi_update_resource.test.output.properties.sku.name
 }

--- a/examples/case2 - for_each/main - migrated.tf
+++ b/examples/case2 - for_each/main - migrated.tf
@@ -25,36 +25,67 @@ variable "accounts" {
   type = map(any)
   default = {
     "item1" = {
-      name = "test1"
+      name = "acctest3505"
       sku  = "Basic"
     }
     "item2" = {
-      name = "test2"
+      name = "acctest62"
       sku  = "Basic"
     }
   }
 }
 
-resource "azurerm_automation_account" "test" {
-  location            = azurerm_resource_group.test.location
-  name                = each.value.name
-  resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "Basic"
-  for_each = {
-    item1 = {
-      name = "henglutest1"
-    }
-    item2 = {
-      name = "henglutest2"
-    }
+# resource "azapi_resource" "test" {
+#   name      = "henglu${each.value.name}"
+#   parent_id = azurerm_resource_group.test.id
+#   type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+# 
+#   location = azurerm_resource_group.test.location
+#   identity {
+#     type = "SystemAssigned"
+#   }
+# 
+#   body = {
+#     properties = {
+#       sku = {
+#         name = each.value.sku
+#       }
+#     }
+#   }
+# 
+#   for_each = var.accounts
+# }
+# 
+removed {
+  from = azapi_resource.test
+  lifecycle {
+    destroy = false
   }
 }
 
-// some comment
-output "sku1" {
-  value = azurerm_automation_account.test["item1"].sku_name
+import {
+  for_each = {
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctest4094/providers/Microsoft.Automation/automationAccounts/hengluacctest3505" = "item1"
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctest4094/providers/Microsoft.Automation/automationAccounts/hengluacctest62"   = "item2"
+  }
+  id = each.key
+  to = azurerm_automation_account.test[each.value]
 }
 
-output "sku2" {
-  value = azurerm_automation_account.test["item2"].sku_name
+resource "azurerm_automation_account" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Basic"
+  location            = azurerm_resource_group.test.location
+  name                = each.value.name
+  identity {
+    type = "SystemAssigned"
+  }
+  for_each = {
+    item1 = {
+      name = "hengluacctest3505"
+    }
+    item2 = {
+      name = "hengluacctest62"
+    }
+  }
 }

--- a/examples/case2 - for_each/main.tf
+++ b/examples/case2 - for_each/main.tf
@@ -47,13 +47,13 @@ resource "azapi_resource" "test" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = each.value.sku
       }
     }
-  })
+  }
 
   for_each = var.accounts
 }

--- a/examples/case3 - nested block/main - migrated.tf
+++ b/examples/case3 - nested block/main - migrated.tf
@@ -36,14 +36,54 @@ variable "defName" {
   default = "def1"
 }
 
+# resource "azapi_resource" "test" {
+#   name      = "henglu-policy"
+#   parent_id = azurerm_resource_group.test.id
+#   type      = "Microsoft.Network/serviceEndpointPolicies@2020-11-01"
+# 
+#   body = {
+#     location = "westeurope"
+#     tags     = {}
+#     properties = {
+#       serviceEndpointPolicyDefinitions = [
+#         {
+#           name = var.defName
+#           properties = {
+#             service     = "Microsoft.Storage"
+#             description = var.description
+#             serviceResources = [
+#               azurerm_storage_account.test.id,
+#               azurerm_resource_group.test.id
+#             ]
+#           }
+#         }
+#       ]
+#     }
+#   }
+# }
+# 
+removed {
+  from = azapi_resource.test
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hl1214-resource-group/providers/Microsoft.Network/serviceEndpointPolicies/henglu-policy"
+  to = azurerm_subnet_service_endpoint_storage_policy.test
+}
+
 resource "azurerm_subnet_service_endpoint_storage_policy" "test" {
   location            = azurerm_resource_group.test.location
   name                = "henglu-policy"
   resource_group_name = azurerm_resource_group.test.name
   definition {
-    description       = var.description
-    name              = var.defName
-    service_resources = [azurerm_resource_group.test.id, azurerm_storage_account.test.id]
+    description = var.description
+    name        = var.defName
+    service_resources = [
+      azurerm_resource_group.test.id,
+      azurerm_storage_account.test.id
+    ]
   }
 }
-

--- a/examples/case3 - nested block/main.tf
+++ b/examples/case3 - nested block/main.tf
@@ -41,25 +41,23 @@ resource "azapi_resource" "test" {
   parent_id   = azurerm_resource_group.test.id
   type        = "Microsoft.Network/serviceEndpointPolicies@2020-11-01"
 
-  body = <<BODY
-{
-    "location": "westeurope",
-    "tags": {},
-    "properties": {
-        "serviceEndpointPolicyDefinitions": [
-            {
-                "name": "${var.defName}",
-                "properties": {
-                    "service": "Microsoft.Storage",
-                    "description": "${var.description}",
-                    "serviceResources": [
-                        "${azurerm_storage_account.test.id}",
-                        "${azurerm_resource_group.test.id}"
-                    ]
-                }
-            }
-        ]
+  body = {
+    location = "westeurope"
+    tags     = {}
+    properties = {
+      serviceEndpointPolicyDefinitions = [
+        {
+          name = var.defName
+          properties = {
+            service     = "Microsoft.Storage"
+            description = var.description
+            serviceResources = [
+              azurerm_storage_account.test.id,
+              azurerm_resource_group.test.id
+            ]
+          }
+        }
+      ]
     }
-}
-  BODY
+  }
 }

--- a/examples/case4 - count/main - migrated.tf
+++ b/examples/case4 - count/main - migrated.tf
@@ -18,11 +18,42 @@ resource "azurerm_resource_group" "test" {
   location = "west europe"
 }
 
+# resource "azapi_resource" "test" {
+#   name      = "henglu${count.index}"
+#   parent_id = azurerm_resource_group.test.id
+#   type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+#   location  = azurerm_resource_group.test.location
+#   body = {
+#     properties = {
+#       sku = {
+#         name = "Basic"
+#       }
+#     }
+#   }
+# 
+#   count = 2
+# }
+# 
+removed {
+  from = azapi_resource.test
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  for_each = {
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu-resource-group/providers/Microsoft.Automation/automationAccounts/henglu0" = 0
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu-resource-group/providers/Microsoft.Automation/automationAccounts/henglu1" = 1
+  }
+  id = each.key
+  to = azurerm_automation_account.test[each.value]
+}
+
 resource "azurerm_automation_account" "test" {
+  name                = "henglu${count.index}"
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "Basic"
   location            = azurerm_resource_group.test.location
-  name                = "henglu${count.index}"
   count               = 2
 }
-

--- a/examples/case4 - count/main.tf
+++ b/examples/case4 - count/main.tf
@@ -23,13 +23,13 @@ resource "azapi_resource" "test" {
   parent_id   = azurerm_resource_group.test.id
   type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
   location    = azurerm_resource_group.test.location
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = "Basic"
       }
     }
-  })
+  }
 
   count = 2
 }

--- a/examples/case5 - nested block patch/main - migrated.tf
+++ b/examples/case5 - nested block patch/main - migrated.tf
@@ -31,14 +31,13 @@ resource "azurerm_container_registry" "test" {
       ip_rule = [
         {
           action   = var.action
-          ip_range = "7.7.7.7/32"
+          ip_range = "2.2.2.2/32"
         },
         {
           action   = var.action
-          ip_range = "2.2.2.2/32"
+          ip_range = "7.7.7.7/32"
         }
       ]
-      virtual_network = []
     }
   ]
 }
@@ -48,3 +47,32 @@ variable "action" {
   default = "Allow"
 }
 
+# resource "azapi_update_resource" "test" {
+#   resource_id = azurerm_container_registry.test.id
+#   type        = "Microsoft.ContainerRegistry/registries@2019-05-01"
+#   body = {
+#     properties = {
+#       networkRuleSet = {
+#         defaultAction = "Deny"
+#         ipRules = [
+#           {
+#             action = var.action
+#             value  = "7.7.7.7"
+#           },
+#           {
+#             action = var.action
+#             value  = "2.2.2.2"
+#           }
+#         ]
+#       }
+#     }
+#   }
+# }
+# 
+
+removed {
+  from = azapi_update_resource.test
+  lifecycle {
+    destroy = false
+  }
+}

--- a/examples/case5 - nested block patch/main.tf
+++ b/examples/case5 - nested block patch/main.tf
@@ -46,23 +46,21 @@ variable "action" {
 resource "azapi_update_resource" "test" {
   resource_id = azurerm_container_registry.test.id
   type        = "Microsoft.ContainerRegistry/registries@2019-05-01"
-  body        = <<BODY
-{
-    "properties": {
-        "networkRuleSet": {
-            "defaultAction": "Deny",
-            "ipRules": [
-                {
-                    "action": "${var.action}",
-                    "value": "7.7.7.7"
-                },
-                {
-                    "action": "${var.action}",
-                    "value": "2.2.2.2"
-                }
-            ]
-        }
+  body = {
+    properties = {
+      networkRuleSet = {
+        defaultAction = "Deny"
+        ipRules = [
+          {
+            action = var.action
+            value  = "7.7.7.7"
+          },
+          {
+            action = var.action
+            value  = "2.2.2.2"
+          }
+        ]
+      }
     }
-}
-    BODY
+  }
 }

--- a/examples/case6 - meta arguments/main - migrated.tf
+++ b/examples/case6 - meta arguments/main - migrated.tf
@@ -18,19 +18,107 @@ resource "azurerm_resource_group" "test" {
   location = "west europe"
 }
 
+# resource "azapi_resource" "test" {
+#   name                   = "henglu1"
+#   parent_id              = azurerm_resource_group.test.id
+#   type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+#   response_export_values = ["name", "identity", "properties.sku"]
+# 
+#   location = azurerm_resource_group.test.location
+#   identity {
+#     type = "SystemAssigned"
+#   }
+# 
+#   body = {
+#     properties = {
+#       sku = {
+#         name = "Basic"
+#       }
+#     }
+#   }
+# 
+#   depends_on = [azurerm_resource_group.test]
+# 
+#   lifecycle {
+#     create_before_destroy = false
+#     prevent_destroy       = false
+#   }
+# 
+#   provisioner "local-exec" {
+#     command = "echo the resource id is ${self.id}"
+#   }
+# }
+# 
+removed {
+  from = azapi_resource.test
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu211220-resource-group/providers/Microsoft.Automation/automationAccounts/henglu1"
+  to = azurerm_automation_account.test
+}
+
 resource "azurerm_automation_account" "test" {
   location            = azurerm_resource_group.test.location
   name                = "henglu1"
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "Basic"
-  depends_on          = [azurerm_resource_group.test]
+  identity {
+    type = "SystemAssigned"
+  }
+  depends_on = [azurerm_resource_group.test]
   lifecycle {
-    create_before_destroy = true
-    prevent_destroy       = true
+    create_before_destroy = false
+    prevent_destroy       = false
   }
   provisioner "local-exec" {
     command = "echo the resource id is ${self.id}"
   }
+}
+
+# resource "azapi_resource" "test1" {
+#   name      = "acctest1831"
+#   parent_id = azurerm_resource_group.test.id
+#   type      = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
+# 
+#   location = azurerm_resource_group.test.location
+#   identity {
+#     type = "SystemAssigned"
+#   }
+# 
+#   body = {
+#     properties = {
+#       sku = {
+#         name = "Basic"
+#       }
+#     }
+#   }
+# 
+#   depends_on = [azurerm_resource_group.test, azapi_resource.test]
+# 
+#   lifecycle {
+#     create_before_destroy = false
+#     prevent_destroy       = false
+#   }
+# 
+#   provisioner "local-exec" {
+#     command = "echo the resource id is ${self.id}"
+#   }
+# }
+# 
+removed {
+  from = azapi_resource.test1
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu211220-resource-group/providers/Microsoft.Automation/automationAccounts/anotherhenglu1"
+  to = azurerm_automation_account.test1
 }
 
 resource "azurerm_automation_account" "test1" {
@@ -38,7 +126,10 @@ resource "azurerm_automation_account" "test1" {
   name                = "anotherhenglu1"
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "Basic"
-  depends_on          = [azurerm_resource_group.test, azurerm_automation_account.test]
+  identity {
+    type = "SystemAssigned"
+  }
+  depends_on = [azurerm_resource_group.test, azurerm_automation_account.test]
   lifecycle {
     create_before_destroy = true
     prevent_destroy       = true
@@ -47,4 +138,4 @@ resource "azurerm_automation_account" "test1" {
     command = "echo the resource id is ${self.id}"
   }
 }
-
+        

--- a/examples/case6 - meta arguments/main.tf
+++ b/examples/case6 - meta arguments/main.tf
@@ -29,13 +29,13 @@ resource "azapi_resource" "test" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = "Basic"
       }
     }
-  })
+  }
 
   depends_on = [azurerm_resource_group.test]
 
@@ -60,13 +60,13 @@ resource "azapi_resource" "test1" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = "Basic"
       }
     }
-  })
+  }
 
   depends_on = [azurerm_resource_group.test, azapi_resource.test]
 

--- a/examples/case7 - ignore/main - migrated.tf
+++ b/examples/case7 - ignore/main - migrated.tf
@@ -46,13 +46,13 @@ resource "azapi_resource" "test" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = local.AutomationSku
       }
     }
-  })
+  }
 }
 
 resource "azapi_resource" "test2" {
@@ -60,13 +60,13 @@ resource "azapi_resource" "test2" {
   parent_id   = azurerm_resource_group.test.id
   type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
   location    = azurerm_resource_group.test.location
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
-        name = jsondecode(azapi_resource.test.output).properties.sku.name
+        name azapi_resource.test.output.properties.sku.name
       }
     }
-  })
+  }
 }
 
 resource "azurerm_automation_account" "test1" {
@@ -80,17 +80,17 @@ resource "azapi_update_resource" "test" {
   resource_id            = azurerm_automation_account.test1.id
   type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
   response_export_values = ["properties.sku"]
-  body = jsonencode({
+  body = {
     tags = {
       key = var.Label
     }
-  })
+  }
 }
 
 output "accountName" {
-  value = jsondecode(azapi_resource.test.output).name
+  value = azapi_resource.test.output.name
 }
 
 output "patchAccountSKU" {
-  value = jsondecode(azapi_update_resource.test.output).properties.sku.name
+  value = azapi_update_resource.test.output.properties.sku.name
 }

--- a/examples/case7 - ignore/main.tf
+++ b/examples/case7 - ignore/main.tf
@@ -46,13 +46,13 @@ resource "azapi_resource" "test" {
     type = "SystemAssigned"
   }
 
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
         name = local.AutomationSku
       }
     }
-  })
+  }
 }
 
 resource "azapi_resource" "test2" {
@@ -60,13 +60,13 @@ resource "azapi_resource" "test2" {
   parent_id   = azurerm_resource_group.test.id
   type        = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
   location    = azurerm_resource_group.test.location
-  body = jsonencode({
+  body = {
     properties = {
       sku = {
-        name = jsondecode(azapi_resource.test.output).properties.sku.name
+        name = azapi_resource.test.output.properties.sku.name
       }
     }
-  })
+  }
 }
 
 resource "azurerm_automation_account" "test1" {
@@ -80,17 +80,17 @@ resource "azapi_update_resource" "test" {
   resource_id            = azurerm_automation_account.test1.id
   type                   = "Microsoft.Automation/automationAccounts@2020-01-13-preview"
   response_export_values = ["properties.sku"]
-  body = jsonencode({
+  body = {
     tags = {
       key = var.Label
     }
-  })
+  }
 }
 
 output "accountName" {
-  value = jsondecode(azapi_resource.test.output).name
+  value = azapi_resource.test.output.name
 }
 
 output "patchAccountSKU" {
-  value = jsondecode(azapi_update_resource.test.output).properties.sku.name
+  value = azapi_update_resource.test.output.properties.sku.name
 }

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,52 @@
 ## Introduction
 This tool is used to migrate resources from terraform `azapi` provider to `azurerm` provider.
 
+
+## Command Usage
+```
+PS C:\Users\henglu\go\src\github.com\Azure\azapi2azurerm> azapi2azurerm.exe            
+Usage: azapi2azurerm [--version] [--help] <command> [<args>]
+
+Available commands are:
+    migrate    Migrate azapi resources to azurerm resources in current working directory
+    plan       Show azapi resources which can migrate to azurerm resources in current working directory
+    version    Displays the version of the migration tool
+```
+
+1. Run `azapi2azurerm plan` under your terraform working directory, 
+   it will list all resources that can be migrated from `azapi` provider to `azurerm` provider.
+   The Terraform addresses listed in file `azapi2azurerm.ignore` will be ignored during migration.
+```
+2022/01/25 14:34:46 [INFO] searching azapi_resource & azapi_update_resource...
+2022/01/25 14:34:55 [INFO]
+
+The tool will perform the following actions:
+
+The following resources will be migrated:
+azapi_resource.test2 will be replaced with azurerm_automation_account
+azapi_update_resource.test will be replaced with azurerm_automation_account
+
+The following resources can't be migrated:
+azapi_resource.test: input properties not supported: [], output properties not supported: [identity.principalId, identity.type, identity.tenantId]
+
+The following resources will be ignored in migration:
+   ```
+2. Run `azapi2azurerm migrate` under your terraform working directory, 
+   it will migrate above resources from `azapi` provider to `azurerm` provider, 
+   both terraform configuration and state.
+   The Terraform addresses listed in file `azapi2azurerm.ignore` will be ignored during migration.
+   
+## Examples
+There're some examples to show the migration results.
+1. [case1 - basic](https://github.com/Azure/azapi2azurerm/tree/master/examples/case1%20-%20basic)
+2. [case2 - for_each](https://github.com/Azure/azapi2azurerm/tree/master/examples/case2%20-%20for_each)
+3. [case3 - nested block](https://github.com/Azure/azapi2azurerm/tree/master/examples/case3%20-%20nested%20block)
+4. [case4 - count](https://github.com/Azure/azapi2azurerm/tree/master/examples/case4%20-%20count)
+5. [case5 - nested block patch](https://github.com/Azure/azapi2azurerm/tree/master/examples/case5%20-%20nested%20block%20patch)
+6. [case6 - meta argument](https://github.com/Azure/azapi2azurerm/tree/master/examples/case6%20-%20meta%20arguments)
+7. [case7 - ignore](https://github.com/Azure/azapi2azurerm/tree/master/examples/case7%20-%20ignore)
+
+
 ## Install
 
 ### From Release
@@ -73,50 +119,6 @@ Supported versions:
 ```bash
 yay -S azapi2azurerm
 ```
-
-## Command Usage
-```
-PS C:\Users\henglu\go\src\github.com\Azure\azapi2azurerm> azapi2azurerm.exe            
-Usage: azapi2azurerm [--version] [--help] <command> [<args>]
-
-Available commands are:
-    migrate    Migrate azapi resources to azurerm resources in current working directory
-    plan       Show azapi resources which can migrate to azurerm resources in current working directory
-    version    Displays the version of the migration tool
-```
-
-1. Run `azapi2azurerm plan` under your terraform working directory, 
-   it will list all resources that can be migrated from `azapi` provider to `azurerm` provider.
-   The Terraform addresses listed in file `azapi2azurerm.ignore` will be ignored during migration.
-```
-2022/01/25 14:34:46 [INFO] searching azapi_resource & azapi_update_resource...
-2022/01/25 14:34:55 [INFO]
-
-The tool will perform the following actions:
-
-The following resources will be migrated:
-azapi_resource.test2 will be replaced with azurerm_automation_account
-azapi_update_resource.test will be replaced with azurerm_automation_account
-
-The following resources can't be migrated:
-azapi_resource.test: input properties not supported: [], output properties not supported: [identity.principalId, identity.type, identity.tenantId]
-
-The following resources will be ignored in migration:
-   ```
-2. Run `azapi2azurerm migrate` under your terraform working directory, 
-   it will migrate above resources from `azapi` provider to `azurerm` provider, 
-   both terraform configuration and state.
-   The Terraform addresses listed in file `azapi2azurerm.ignore` will be ignored during migration.
-   
-## Examples
-There're some examples to show the migration results.
-1. [case1 - basic](https://github.com/Azure/azapi2azurerm/tree/master/examples/case1%20-%20basic)
-2. [case2 - for_each](https://github.com/Azure/azapi2azurerm/tree/master/examples/case2%20-%20for_each)
-3. [case3 - nested block](https://github.com/Azure/azapi2azurerm/tree/master/examples/case3%20-%20nested%20block)
-4. [case4 - count](https://github.com/Azure/azapi2azurerm/tree/master/examples/case4%20-%20count)
-5. [case5 - nested block patch](https://github.com/Azure/azapi2azurerm/tree/master/examples/case5%20-%20nested%20block%20patch)
-6. [case6 - meta argument](https://github.com/Azure/azapi2azurerm/tree/master/examples/case6%20-%20meta%20arguments)
-7. [case7 - ignore](https://github.com/Azure/azapi2azurerm/tree/master/examples/case7%20-%20ignore)
    
 ## Features
 - [x] Support resource `azapi_resource` migration

--- a/tf/terraform.go
+++ b/tf/terraform.go
@@ -225,15 +225,6 @@ func (t *Terraform) Apply() error {
 	return t.exec.Apply(context.TODO())
 }
 
-func (t *Terraform) RefreshState(resources []string) error {
-	// TODO: replace refresh command with apply -refresh-only
-	opts := make([]tfexec.RefreshCmdOption, 0)
-	for _, res := range resources {
-		opts = append(opts, tfexec.Target(res))
-	}
-	return t.exec.Refresh(context.TODO(), opts...)
-}
-
 func (t *Terraform) Destroy() error {
 	return t.exec.Destroy(context.TODO())
 }


### PR DESCRIPTION
In previous implementation, the migration tool would modify the user's terraform state directly which is risky. This PR introduces a new migration flow which uses the `import` and `removed` block to do the state modification. By doing this, the user could review and test the configuration changes in a dev environment, then push the changes in a prod environment.